### PR TITLE
[MISC] Re use the document error's status code for response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### Enhancements
 
-* [#3](https://github.com/Decisiv/calcinator/pull/3) - [@edipox](https://github.com/edipox)
+* [#2](https://github.com/Decisiv/calcinator/pull/2) - [@edipox](https://github.com/edipox)
  * Update `Calcinator.Controller.Error.put_calcinator_error` in order to render a response using the status code from the error whenever is possible.
 
 ## v5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [v5.2.0](#v510)
+    - [Enhancements](#enhancements)
   - [v5.1.0](#v510)
     - [Enhancements](#enhancements)
     - [Bug Fixes](#bug-fixes)
@@ -61,9 +63,17 @@
 
 # Changelog
 
+## v5.2.0
+
+### Enhancements
+
+* [#3](https://github.com/Decisiv/calcinator/pull/3) - [@edipox](https://github.com/edipox)
+ * Update `Calcinator.Controller.Error.put_calcinator_error` in order to render a response using the status code from the error whenever is possible.
+
 ## v5.1.0
 
 ### Enhancements
+*
 * [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
   * Update to latest `mix.lock` format.
   * JaSerializer [supports](https://github.com/vt-elixir/ja_serializer#fields) [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets), but `Calcinator.JaSerializer.PhoenixView`'s `params_to_render_opts/1` was only copying `params["include"]` to `opts[:include]`, so now copy over both `"include"` and `"fields"` if present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 ## v5.1.0
 
 ### Enhancements
-*
+
 * [#36](https://github.com/C-S-D/calcinator/pull/36) - [@KronicDeth](https://github.com/KronicDeth)
   * Update to latest `mix.lock` format.
   * JaSerializer [supports](https://github.com/vt-elixir/ja_serializer#fields) [sparse fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets), but `Calcinator.JaSerializer.PhoenixView`'s `params_to_render_opts/1` was only copying `params["include"]` to `opts[:include]`, so now copy over both `"include"` and `"fields"` if present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### Enhancements
 
-* [#2](https://github.com/Decisiv/calcinator/pull/2) - [@edipox](https://github.com/edipox)
+* [#3](https://github.com/Decisiv/calcinator/pull/3) - [@edipox](https://github.com/edipox)
  * Update `Calcinator.Controller.Error.put_calcinator_error` in order to render a response using the status code from the error whenever is possible.
 
 ## v5.1.0

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,11 +7,11 @@ config :calcinator, Calcinator.Endpoint,
 config :calcinator, Calcinator.Resources.Ecto.Repo.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "calcinator_test",
-  hostname: "localhost",
+  hostname: System.get_env("DATABASE_HOST") || "localhost",
   loggers: [PryIn.EctoLogger, Ecto.LogEntry],
-  password: "postgres",
+  password: System.get_env("DATABASE_PASSWORD") || "",
   pool: Ecto.Adapters.SQL.Sandbox,
-  username: "postgres"
+  username: System.get_env("DATABASE_USERNAME") || "postgres"
 
 config :calcinator,
   ecto_repos: [Calcinator.Resources.Ecto.Repo.Repo],

--- a/lib/calcinator/controller/error.ex
+++ b/lib/calcinator/controller/error.ex
@@ -77,6 +77,25 @@ if Code.ensure_loaded?(Phoenix.Controller) do
     def put_calcinator_error(conn, {:error, :timeout}), do: gateway_timeout(conn)
     def put_calcinator_error(conn, {:error, :unauthorized}), do: forbidden(conn)
 
+    def put_calcinator_error(
+          conn,
+          {:error, document = %Alembic.Document{errors: errors = [%Alembic.Error{status: status}]}}
+        )
+        when length(errors) == 1 and not is_nil(status) and (is_atom(status) or is_number(status)) do
+      render_json(conn, document, status)
+    end
+
+    def put_calcinator_error(
+          conn,
+          {:error,
+           document = %Alembic.Document{
+             errors: errors = [%Alembic.Error{status: status}]
+           }}
+        )
+        when length(errors) == 1 and is_binary(status) do
+      render_json(conn, document, String.to_integer(status))
+    end
+
     def put_calcinator_error(conn, {:error, document = %Alembic.Document{}}) do
       render_json(conn, document, :unprocessable_entity)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Calcinator.Mixfile do
       test_coverage: [
         tool: ExCoveralls
       ],
-      version: "5.1.0"
+      version: "5.2.0"
     ]
   end
 


### PR DESCRIPTION
#### What does this PR do?
* Re use the document error's status code for the response on `Calcinator.Controller.Error.put_calcinator_error`
* Adds tests accordingly

#### Other Questions:
- [X] Did I run this locally?
- [X] Did I run the whole test suite?
- [X] Did I add tests to cover the change?
- [ ] Any additional deploy/release considerations?
- [ ] Does this PR cause necessary updates to the FAQ / documentation?
- [ ] Does the `VERSION` file properly reflect the changes in this PR?